### PR TITLE
Sets up basic Vue project structure

### DIFF
--- a/project/index.html
+++ b/project/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Бронирование столика в кафе</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/project/jsconfig.json
+++ b/project/jsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-  "exclude": ["node_modules", "dist"]
-}

--- a/project/package-lock.json
+++ b/project/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "reserch_vue",
+  "name": "project",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "reserch_vue",
+      "name": "project",
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.5.13"

--- a/project/package.json
+++ b/project/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reserch_vue",
+  "name": "project",
   "version": "0.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Initializes a basic Vue project structure with an `index.html` entry point.

Removes the `jsconfig.json` file, as it's not immediately needed.

Updates `package.json` and `package-lock.json` to reflect the project's name change from "reserch_vue" to "project".